### PR TITLE
case-insensitive tags matching

### DIFF
--- a/usecases/findtags.go
+++ b/usecases/findtags.go
@@ -38,13 +38,13 @@ func (s FindTagsUsecase) FindTags(cmd FindTagsCmd) (FindTagsResult, error) {
 		return FindTagsResult{}, errors.New("failed extracting paragraphs: " + err.Error())
 	}
 
-	rgx := regexp.MustCompile(strings.Join(cmd.Tags, "|"))
+	rgx := regexp.MustCompile("(?i)" + strings.Join(cmd.Tags, "|"))
 	matches := make(map[string]int)
 	for _, p := range paragraphs {
 		found := rgx.FindAllString(p, -1)
-
 		for _, match := range found {
-			matches[match] = matches[match] + 1
+			tag := strings.ToLower(match)
+			matches[tag]++
 		}
 	}
 


### PR DESCRIPTION
Resolve https://github.com/co0p/x-scrap/issues/6

before: 
```
> go run cmd/xscrap/main.go -urls  https://kreuzwerker.de/post/aws-re-inforce-2022,https://kreuzwerker.de/post/the-not-so-short-journey-from-azure-devops-to-gitlab-ci -tags aws,security

url: https://kreuzwerker.de/post/aws-re-inforce-2022
-----------------------
aws:      0
security: 9

url: https://kreuzwerker.de/post/the-not-so-short-journey-from-azure-devops-to-gitlab-ci
-----------------------
aws:      0
security: 11
```

after:
```
> go run cmd/xscrap/main.go -urls  https://kreuzwerker.de/post/aws-re-inforce-2022,https://kreuzwerker.de/post/the-not-so-short-journey-from-azure-devops-to-gitlab-ci -tags aws,security

url: https://kreuzwerker.de/post/aws-re-inforce-2022
-----------------------
aws:      12
security: 10

url: https://kreuzwerker.de/post/the-not-so-short-journey-from-azure-devops-to-gitlab-ci
-----------------------
aws:      18
security: 12
```